### PR TITLE
Fixes checkstyle preceding whitespace on generated TestApplication file in the application archetype module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ your application.
 
 
     mvn -B archetype:generate -DarchetypeGroupId=com.github.katari \
-      -DarchetypeArtifactId=k2-archetype-application -DarchetypeCatalog=local \
+      -DarchetypeArtifactId=k2-archetype-application -DarchetypeVersion=0.1.8 \ 
+      -DarchetypeCatalog=local \
       -DgroupId=sample -DartifactId=sample \
       -Dpackage=sample -DclassPrefix=Sample -Dversion=0.1-SNAPSHOT
 
@@ -69,7 +70,8 @@ your application.
 This is the command we used to generate the k2-shiro module:
 
     mvn -B archetype:generate -DarchetypeGroupId=com.github.katari \
-      -DarchetypeArtifactId=k2-archetype-module -DarchetypeCatalog=local \
+      -DarchetypeArtifactId=k2-archetype-module -DarchetypeVersion=0.1.8 \
+      -DarchetypeCatalog=local \
       -DgroupId=com.github.katari -DartifactId=k2-shiro \
       -Dpackage=com.k2.shiro -DclassPrefix=Shiro -Dversion=0.1-SNAPSHOT
 

--- a/k2-archetype-application/src/main/resources/archetype-resources/__rootArtifactId__/src/test/java/__packageInPathFormat__/TestApplication.java
+++ b/k2-archetype-application/src/main/resources/archetype-resources/__rootArtifactId__/src/test/java/__packageInPathFormat__/TestApplication.java
@@ -77,7 +77,7 @@ public class TestApplication extends Application {
     // Ignore all calls to stop, just in case.
   }
 
-  public static void main(final String ... args) {
+  public static void main(final String... args) {
     application = new TestApplication();
     application.run(args);
   }


### PR DESCRIPTION
It also modifies the main project README.md file as the suggested maven commands do not run successfully without specifying the archetypeVersion. The latest archetype version (0.1.8) was chosen as an example.